### PR TITLE
Added more options

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -382,6 +382,13 @@ function handleObjectBlock(block, index, columndiv, width, c) {
             dataType: 'script'
         });
         $(columndiv).append(loadPublicTransport(random, block, key));
+    } else if (block.hasOwnProperty('trafficJams') || block.hasOwnProperty('roadWorks') || block.hasOwnProperty('radars')) {
+        if (typeof(loadTrafficInfo) !== 'function') $.ajax({
+            url: 'js/trafficinfo.js',
+            async: false,
+            dataType: 'script'
+        });
+        $(columndiv).append(loadTrafficInfo(random, block, key));
     } else if (block.hasOwnProperty('currency')) {
         if (typeof(getCoin) !== 'function') $.ajax({url: 'js/coins.js', async: false, dataType: 'script'});
         var html = '<div class="col-xs-' + width + ' transbg coins-' + block['key'] + '" data-id="coins.' + block['key'] + '"></div>';

--- a/js/publictransport.js
+++ b/js/publictransport.js
@@ -77,33 +77,67 @@ function dataPublicTransport(random,data,transportobject){
 			for(t in data[d]){
 				var l_id= data[d][t]['id'];
 				if(provider == '9292' || 
-				   (l_id=='bus' && provider == '9292-bus') || 
-					 (l_id=='tram' && provider == '9292-tram')  ||
-					 (l_id=='bus' && provider == '9292-tram-bus')  ||
-					 (l_id=='tram' && provider == '9292-tram-bus')  ||
-					 (l_id=='tram-bus' && provider == '9292-tram-bus') || 
-				   (l_id=='metro' && provider == '9292-metro') || 
-				   (l_id=='trein' && provider == '9292-train') || 
-				   (l_id=='veerboot' && provider == '9292-boat')
+					(l_id=='bus' && provider == '9292-bus') || 
+					(l_id=='tram' && provider == '9292-tram')  ||
+					(l_id=='bus' && provider == '9292-tram-bus')  ||
+					(l_id=='tram' && provider == '9292-tram-bus')  ||
+					(l_id=='tram-bus' && provider == '9292-tram-bus') || 
+					(l_id=='bus-tram' && provider == '9292-tram-bus') || 
+					(l_id=='tram-metro' && provider == '9292-tram-bus') || 
+					(l_id=='metro' && provider == '9292-metro') || 
+					(l_id=='trein' && provider == '9292-train') || 
+					(l_id=='veerboot' && provider == '9292-boat')
 				){
 					deps = data[d][t]['departures'];
 					for(de in deps){
 						key = deps[de]['time'];
-						if(typeof(dataPart[key])=='undefined') dataPart[key]=[];
-						dataPart[key][i]='';
-						dataPart[key][i]+='<div><b>'+deps[de]['time']+'</b> ';
-						if(deps[de]['realtimeText']!=null) dataPart[key][i]+='<span id="latetrain">'+deps[de]['realtimeText'].replace(' min.','')+'</span> ';
-						if(deps[de]['platform']!=null) dataPart[key][i]+='- Spoor '+deps[de]['platform'];
-						else dataPart[key][i]+='- Lijn '+deps[de]['service'];
-						
-						dest = deps[de]['destinationName'].split(' via ');
-						dataPart[key][i]+=' - '+dest[0];
-						if(typeof(transportobject.show_via)=='undefined' || transportobject.show_via==true){
-							if(typeof(dest[1])!=='undefined') dataPart[key][i]+=' via '+dest[1];
-							else if(typeof(deps[de]['RouteTekst'])!=='undefined') dataPart[key][i]+=' via '+deps[de]['viaNames'];
+						if(typeof(transportobject.destination)!='undefined'){
+							var destinationArray = [];
+							if(transportobject.destination.indexOf(',')){
+							   destinationArray = transportobject.destination.split(/, |,/);
+							} else {
+							   destinationArray.push(transportobject.destination);
+							}
 						}
-						dataPart[key][i]+=' </div>';
-						i++;
+						if(typeof(transportobject.service)!='undefined'){
+							var serviceArray = [];
+							if(transportobject.service.indexOf(',')){
+							   serviceArray = transportobject.service.split(/, |,/);
+							} else {
+							   serviceArray.push(transportobject.service);
+							}
+						}
+						if(typeof(transportobject.destination)=='undefined' && typeof(transportobject.service)=='undefined' ||
+							((typeof(transportobject.destination)!='undefined' && destinationArray.indexOf(deps[de]['destinationName']) > -1) && typeof(transportobject.service)=='undefined') ||
+							((typeof(transportobject.service)!='undefined' && serviceArray.indexOf(deps[de]['service']) > -1) && typeof(transportobject.destination)=='undefined') ||
+							((typeof(transportobject.destination)!='undefined' && destinationArray.indexOf(deps[de]['destinationName']) > -1) && (typeof(transportobject.service)!='undefined' && serviceArray.indexOf(deps[de]['service']) > -1))
+							)
+						{
+							if(typeof(dataPart[key])=='undefined') {
+								dataPart[key]=[];
+							}
+							dataPart[key][i]='';
+							dataPart[key][i]+='<div><b>'+deps[de]['time']+'</b> ';
+							if(deps[de]['realtimeText']!=null) {
+								dataPart[key][i]+='<span id="latetrain">'+deps[de]['realtimeText'].replace(' min.','')+'</span> ';
+							}	
+							if(deps[de]['platform']!=null) {
+								dataPart[key][i]+='- Spoor '+deps[de]['platform'];
+							} else {
+								dataPart[key][i]+='- Lijn '+deps[de]['service'];
+							}
+							dest = deps[de]['destinationName'].split(' via ');
+							dataPart[key][i]+=' - '+dest[0];
+							if(typeof(transportobject.show_via)=='undefined' || transportobject.show_via==true){
+								if(typeof(dest[1])!=='undefined') {
+									dataPart[key][i]+=' via '+dest[1];
+								} else if(typeof(deps[de]['RouteTekst'])!=='undefined') {
+									dataPart[key][i]+=' via '+deps[de]['viaNames'];
+								}	
+							}
+							dataPart[key][i]+=' </div>';
+							i++;
+						}
 					}
 				}
 			}

--- a/js/trafficinfo.js
+++ b/js/trafficinfo.js
@@ -1,0 +1,169 @@
+function loadTrafficInfo(random,trafficobject,key){
+	var width = 12;
+	if(typeof(trafficobject.width)!=='undefined') width=trafficobject.width;
+	var html='<div data-id="trafficinfo.'+key+'" class="col-xs-'+width+'" style="padding-left:0px !important;padding-right:0px !important;">';
+	if(typeof(trafficobject.title)!=='undefined') html+='<div class="col-xs-12 mh titlegroups transbg"><h3>'+trafficobject.title+'</h3></div>';
+					
+	html+='<div class="trafficinfo trafficinfo'+random+' col-xs-12 transbg">';
+		if(typeof(trafficobject.icon)!=='undefined' && trafficobject.icon!==''){
+			if(trafficobject.icon.substr(0,2)!=='fas') trafficobject.icon = 'fa-'+trafficobject.icon;
+			html+='<div class="col-xs-2 col-icon">';
+				html+='<em class="fas '+trafficobject.icon+'"></em>';
+			html+='</div>';
+			html+='<div class="col-xs-10 col-data">';
+				html+='<span class="state"></span>';
+			html+='</div>';
+		}
+		else {
+				html+='<div class="col-xs-12 col-data">';
+					html+='<span class="state"></span>';
+				html+='</div>';
+		}
+		html+='</div>';	
+	
+	html+='</div>';	
+	
+	//Get data every interval and call function to create block
+	var interval = 60;
+	if(typeof(trafficobject.interval)!=='undefined') interval = trafficobject.interval;
+	setTimeout(function(){
+		$('.trafficinfo'+random+' .state').html(language.misc.loading);
+		getProviderData(random,trafficobject);
+	},100);
+	
+	if(trafficobject.provider.toLowerCase() == 'ns'){
+		if(parseFloat(interval)<60) interval=60; // limit request because of limitations in NS api for my private key ;)
+	}
+	
+	setInterval(function(){
+		getProviderData(random,trafficobject)
+	},(interval * 1000));
+	return html;
+}
+
+function getProviderData(random,trafficobject){
+	var provider = trafficobject.provider.toLowerCase();
+	var dataURL = '';
+	if(provider == 'anwb'){
+		dataURL = 'https://www.anwb.nl/feeds/gethf';
+	}
+	// To do:
+	//else if(provider == 'flitsmeister'){
+	//	dataURL = _CORS_PATH + 'http://tesla.flitsmeister.nl/teslaFeed.json';
+	//}
+	
+	$.getJSON(dataURL,function(data){
+		dataTrafficInfo(random,data,trafficobject);
+	});
+	
+}
+function dataTrafficInfo(random,data,trafficobject){
+	var provider = trafficobject.provider.toLowerCase();
+	var dataPart = {}
+	var i = 0;
+	for(d in data){
+		if(provider == 'anwb'){
+			if(d == 'roadEntries'){
+				if (typeof(trafficobject.road)!='undefined'){
+					var roadArray = [];
+					if (trafficobject.road.indexOf(',')){
+					   roadArray = trafficobject.road.split(/, |,/);
+					} else {
+					   roadArray.push(trafficobject.road);
+					}
+					roadArray.sort();
+ 					for (var x = 0; x < roadArray.length; x++){
+						key = roadArray[x];
+						if (typeof(dataPart[key])=='undefined') {
+							dataPart[key]=[];
+						}
+						dataPart[key][i]='';
+						dataPart[key][i]+='<div><b>'+roadArray[x]+'</b><br>';
+						dataPart[key][i]+='Geen verkeersinformatie';
+						dataPart[key][i]+='<br></div>';
+					}
+				}		
+				for(t in data[d]){
+					
+					var roadId = data[d][t]['road'];
+			
+					if (typeof(trafficobject.road)=='undefined' || (typeof(trafficobject.road)!='undefined' && roadArray.indexOf(roadId) > -1)) {
+						events = data[d][t]['events'];
+						var header = '';
+						for(ev in events){
+							if ((typeof(trafficobject.trafficJams)=='undefined' || (trafficobject.trafficJams==true && ev=='trafficJams')) || 
+								(typeof(trafficobject.roadWorks)=='undefined' || (trafficobject.roadWorks==true && ev=='roadWorks')) ||
+								(typeof(trafficobject.radars)=='undefined' || (trafficobject.radars==true && ev=='radars'))) {
+								i = 0;	
+								for(e in events[ev]){
+									if ((typeof(trafficobject.segStart)=='undefined' || (typeof(trafficobject.segStart)!='undefined' && events[ev][e]['segStart']==trafficobject.segStart)) &&
+									(typeof(trafficobject.segEnd)=='undefined' || (typeof(trafficobject.segEnd)!='undefined' && events[ev][e]['segEnd']==trafficobject.segEnd))
+									){
+										key = roadId;
+										if(typeof(dataPart[key])=='undefined') {
+											dataPart[key]=[];
+										}
+										dataPart[key][i]='';
+										if(key != header) {
+											dataPart[key][i]+='<div><b>'+data[d][t]['road']+'</b><br>';
+											header = key;
+										}
+										if(events[ev][e]['location']!=null) {
+											dataPart[key][i]+=events[ev][e]['location'];	
+										}
+										if(events[ev][e]['distance']!=null){
+											var distance = events[ev][e]['distance']/1000;
+											dataPart[key][i]+=', '+distance.toFixed(1)+'km';
+										}
+										if(events[ev][e]['delay']!=null){
+											var delay = events[ev][e]['delay']/60;
+											dataPart[key][i]+=' - '+Math.round(delay)+'min';
+										}
+										dataPart[key][i]+=':<br>';
+										if(events[ev][e]['description']!=null) {
+											dataPart[key][i]+=events[ev][e]['description'];
+										}
+										dataPart[key][i]+='<br></div>';
+										i++;
+									}
+								}
+							}
+						}
+					}
+				}				
+			} 	
+		}
+	}
+	$('.trafficinfo'+random+' .state').html('');
+	var c = 1;
+	Object.keys(dataPart).forEach(function(d) {
+	//Object.keys(dataPart).sort().forEach(function(d) {
+		for(p in dataPart[d]){
+			if(c <= trafficobject.results) $('.trafficinfo'+random+' .state').append(dataPart[d][p]);
+			c++;
+		}
+	});
+	
+	if(typeof(trafficobject.show_lastupdate)!=='undefined' && trafficobject.show_lastupdate==true){
+		var dt = new Date();
+		$('.trafficinfo'+random+' .state').append('<em>'+language.misc.last_update+': '+addZero(dt.getHours()) + ":"+addZero(dt.getMinutes())+":"+addZero(dt.getSeconds())+'</em>')
+	}
+}
+
+function addZero(input){
+	if(input < 10){
+		return '0' + input;
+	}
+	else{
+		return input;
+	}
+}
+function addMinutes(time/*"hh:mm"*/, minsToAdd/*"N"*/) {
+  function z(n){
+    return (n<10? '0':'') + n;
+  }
+  var bits = time.split(':');
+  var mins = bits[0]*60 + (+bits[1]) + (+minsToAdd);
+
+  return z(mins%(24*60)/60 | 0) + ':' + z(mins%60);  
+}


### PR DESCRIPTION
Traffic information based on providers, ANWB is the first one.
Example:
trafficinfo.anwbA4 = { trafficJams: true, roadWorks: false, radars: false, road:'A4', provider: 'anwb', show_lastupdate:true, icon: 'car', width:12, results: 100 };
segStart and segEnd can also be provided to filter the results even more.

Extra Publictransport options and filter settings:
Updated providers with more id options
Added extra configuration to filter the results:
- destination: set the end destination to filter the direction
- service: set the "lijn" to filter the different lines possible on a stop
Example:
publictransport.ovinfotram = { show_via: true, station: 'den-haag/tramhalte-metrostation-leidschenveen', title:'Station Leidschenveen', destination:'Den Haag De Uithof,Den Haag Loosduinen', service:'3,4', provider: '9292-tram-bus', show_lastupdate:true, icon: 'bus', width:12, results: 8 };